### PR TITLE
Country Feature Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ status.localVersion // (1.2.1)
 status.storeVersion // (1.2.3)
 status.appStoreLink // (https://itunes.apple.com/us/app/google/id284815942?mt=8)
 ```
+
+If you want to get an specific country version of your app, just add the `storeLanguage` when you create an instance of `NewVersion`.
+
+`final new Version = NewVersion(context, country='CL')`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ status.storeVersion // (1.2.3)
 status.appStoreLink // (https://itunes.apple.com/us/app/google/id284815942?mt=8)
 ```
 
-If you want to get an specific country version of your app, just add the `storeLanguage` when you create an instance of `NewVersion`.
+### Options
+`BuildContext context`
+This is required to check the user's platform and display alert dialogs.
 
-`final new Version = NewVersion(context, country='CL')`
+`String androidId`
+An optional value that can override the default packageName when attempting to reach the Google Play Store. This is useful if your app has a different package name in the Play Store.
+
+`String iOSId`
+An optional value that can override the default packageName when attempting to reach the Apple App Store. This is useful if your app has a different package name in the App Store.
+
+`VoidCallback dismissAction`
+An optional value that can override the default callback to dismiss button.
+
+`String dialogText`
+An optional value that can override the default text to alert, you can ${versionStatus.localVersion} to ${versionStatus.storeVersion} to determinate in the text a versions.
+
+`String dialogTitle`
+An optional value that can override the default title of alert dialog.
+
+`String dismissText`
+An optional value that can override the default text of dismiss button.
+
+`String updateText`
+An optional value that can override the default text of update button.
+
+`String iOSAppStoreCountry`
+Only affects iOS App Store lookup: The two-letter country code for the store you want to search. Provide a value here if your app is only available outside the US. For example: US. The default is US. See http://en.wikipedia.org/wiki/ ISO_3166-1_alpha-2 for a list of ISO Country Codes.

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -93,7 +93,9 @@ class NewVersion {
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
         final id = androidId ?? packageInfo.packageName;
-        versionStatus = await _getAndroidStoreVersion(id, versionStatus);
+        final countrycode = storeCountry == null ? '' : '&gl=$storeCountry';
+        versionStatus =
+            await _getAndroidStoreVersion(id, countrycode, versionStatus);
         break;
       case TargetPlatform.iOS:
         final id = iOSId ?? packageInfo.packageName;
@@ -131,9 +133,10 @@ class NewVersion {
   }
 
   /// Android info is fetched by parsing the html of the app store page.
-  _getAndroidStoreVersion(String id, VersionStatus versionStatus) async {
-    final uri =
-        Uri.https("play.google.com", "/store/apps/details", {"id": "$id"});
+  _getAndroidStoreVersion(
+      String id, String countrycode, VersionStatus versionStatus) async {
+    final uri = Uri.https("play.google.com", "/store/apps/details",
+        {"id": "$id", "gl": countrycode});
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       print('Can\'t find an app in the Play Store with the id: $id');

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -58,8 +58,8 @@ class NewVersion {
   /// An optional value that can override the default text of update button
   String updateText;
 
-  /// An optional value that can override the default store language
-  String storeLanguage;
+  /// An optional value that can override the default store country
+  String storeCountry;
 
   NewVersion({
     this.androidId,
@@ -70,7 +70,7 @@ class NewVersion {
     this.updateText: 'Update',
     this.dialogText,
     this.dialogTitle: 'Update Available',
-    this.storeLanguage,
+    this.storeCountry,
   }) : assert(context != null);
 
   /// This checks the version status, then displays a platform-specific alert
@@ -97,8 +97,10 @@ class NewVersion {
         break;
       case TargetPlatform.iOS:
         final id = iOSId ?? packageInfo.packageName;
-        final language = storeLanguage == null ? '' : '&country=$storeLanguage';
-        versionStatus = await _getiOSStoreVersion(id, language, versionStatus);
+        final countrycode =
+            storeCountry == null ? '' : '&country=$storeCountry';
+        versionStatus =
+            await _getiOSStoreVersion(id, countrycode, versionStatus);
         break;
       default:
         print('This target platform is not yet supported by this package.');
@@ -114,9 +116,9 @@ class NewVersion {
   /// iOS info is fetched by using the iTunes lookup API, which returns a
   /// JSON document.
   _getiOSStoreVersion(
-      String id, String language, VersionStatus versionStatus) async {
+      String id, String countryCode, VersionStatus versionStatus) async {
     final uri = Uri.https("itunes.apple.com", "/lookup",
-        {"bundleId": "$id", "country": language});
+        {"bundleId": "$id", "country": countryCode});
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       print('Can\'t find an app in the App Store with the id: $id');

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -127,7 +127,6 @@ class NewVersion {
       return null;
     }
     final jsonObj = json.decode(response.body);
-    print(uri.toString());
     versionStatus.storeVersion = jsonObj['results'][0]['version'];
     versionStatus.appStoreLink = jsonObj['results'][0]['trackViewUrl'];
     return versionStatus;

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -58,6 +58,9 @@ class NewVersion {
   /// An optional value that can override the default text of update button
   String updateText;
 
+  /// An optional value that can override the default store language
+  String storeLanguage;
+
   NewVersion({
     this.androidId,
     this.iOSId,
@@ -67,6 +70,7 @@ class NewVersion {
     this.updateText: 'Update',
     this.dialogText,
     this.dialogTitle: 'Update Available',
+    this.storeLanguage,
   }) : assert(context != null);
 
   /// This checks the version status, then displays a platform-specific alert
@@ -93,7 +97,8 @@ class NewVersion {
         break;
       case TargetPlatform.iOS:
         final id = iOSId ?? packageInfo.packageName;
-        versionStatus = await _getiOSStoreVersion(id, versionStatus);
+        final language = storeLanguage == null ? '' : '&country=$storeLanguage';
+        versionStatus = await _getiOSStoreVersion(id, language, versionStatus);
         break;
       default:
         print('This target platform is not yet supported by this package.');
@@ -109,7 +114,8 @@ class NewVersion {
   /// iOS info is fetched by using the iTunes lookup API, which returns a
   /// JSON document.
   _getiOSStoreVersion(String id, VersionStatus versionStatus) async {
-    final uri = Uri.https("itunes.apple.com", "/lookup", {"bundleId": "$id"});
+    final uri = Uri.https("itunes.apple.com", "/lookup",
+        {"bundleId": "$id", "country": storeLanguage});
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       print('Can\'t find an app in the App Store with the id: $id');

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -33,15 +33,15 @@ class NewVersion {
 
   /// An optional value that can override the default packageName when
   /// attempting to reach the Google Play Store. This is useful if your app has
-  /// a different package name in the Play Store for some reason.
+  /// a different package name in the Play Store.
   String androidId;
 
   /// An optional value that can override the default packageName when
   /// attempting to reach the Apple App Store. This is useful if your app has
-  /// a different package name in the App Store for some reason.
+  /// a different package name in the App Store.
   String iOSId;
 
-  /// An optional value that can override the default callback to dismiss button
+  /// An optional value that can override the default callback to dismiss button.
   VoidCallback dismissAction;
 
   /// An optional value that can override the default text to alert,
@@ -49,13 +49,13 @@ class NewVersion {
   /// to determinate in the text a versions.
   String dialogText;
 
-  /// An optional value that can override the default title of alert dialog
+  /// An optional value that can override the default title of alert dialog.
   String dialogTitle;
 
-  /// An optional value that can override the default text of dismiss button
+  /// An optional value that can override the default text of dismiss button.
   String dismissText;
 
-  /// An optional value that can override the default text of update button
+  /// An optional value that can override the default text of update button.
   String updateText;
 
   /// Only affects iOS App Store lookup: The two-letter country code for the store you want to search.

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -113,9 +113,10 @@ class NewVersion {
 
   /// iOS info is fetched by using the iTunes lookup API, which returns a
   /// JSON document.
-  _getiOSStoreVersion(String id, VersionStatus versionStatus) async {
+  _getiOSStoreVersion(
+      String id, String language, VersionStatus versionStatus) async {
     final uri = Uri.https("itunes.apple.com", "/lookup",
-        {"bundleId": "$id", "country": storeLanguage});
+        {"bundleId": "$id", "country": language});
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       print('Can\'t find an app in the App Store with the id: $id');


### PR DESCRIPTION
~~I Change the endpoint of the appstore changing 
`https://itunes.apple.com/lookup?bundleId=$id`
to
`https://itunes.apple.com/lookup?id=$id`~~

I added a feature to choose the country for the store (Android & iOS).