### PR TITLE
Return release notes with VersionStatus

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,12 +24,40 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
 
-    // Implementation is here
+    // Instantiate NewVersion manager object (Using GCP Console app as example)
     final newVersion = NewVersion(
       iOSId: 'com.google.Vespa',
       androidId: 'com.google.android.apps.cloudconsole',
     );
+
+    // You can let the plugin handle fetching the status and showing a dialog,
+    // or you can fetch the status and display your own dialog, or no dialog.
+    const simpleBehavior = true;
+
+    if (simpleBehavior) {
+      basicStatusCheck(newVersion);
+    } else {
+      advancedStatusCheck(newVersion);
+    }
+  }
+
+  basicStatusCheck(NewVersion newVersion) {
     newVersion.showAlertIfNecessary(context: context);
+  }
+
+  advancedStatusCheck(NewVersion newVersion) async {
+    final status = await newVersion.getVersionStatus();
+    debugPrint(status.releaseNotes);
+    debugPrint(status.appStoreLink);
+    debugPrint(status.localVersion);
+    debugPrint(status.storeVersion);
+    debugPrint(status.canUpdate.toString());
+    newVersion.showUpdateDialog(
+      context: context,
+      versionStatus: status,
+      dialogTitle: 'Custom Title',
+      dialogText: 'Custom Text',
+    );
   }
 
   @override

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -23,7 +23,9 @@ class VersionStatus {
   /// A link to the app store page where the app can be updated.
   final String appStoreLink;
 
+  /// The release notes for the store version of the app.
   final String? releaseNotes;
+
   /// True if the there is a more recent version of the app in the store.
   // bool get canUpdate => localVersion.compareTo(storeVersion).isNegative;
   // version strings can be of the form xx.yy.zz (build)
@@ -123,6 +125,7 @@ class NewVersion {
       localVersion: packageInfo.version,
       storeVersion: jsonObj['results'][0]['version'],
       appStoreLink: jsonObj['results'][0]['trackViewUrl'],
+      releaseNotes: jsonObj['results'][0]['releaseNotes'],
     );
   }
 

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -23,6 +23,7 @@ class VersionStatus {
   /// A link to the app store page where the app can be updated.
   final String appStoreLink;
 
+  final String? releaseNotes;
   /// True if the there is a more recent version of the app in the store.
   // bool get canUpdate => localVersion.compareTo(storeVersion).isNegative;
   // version strings can be of the form xx.yy.zz (build)
@@ -52,6 +53,7 @@ class VersionStatus {
     required this.localVersion,
     required this.storeVersion,
     required this.appStoreLink,
+    this.releaseNotes,
   });
 }
 

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -141,14 +141,27 @@ class NewVersion {
       return null;
     }
     final document = parse(response.body);
-    final elements = document.getElementsByClassName('hAyfc');
-    final versionElement = elements.firstWhere(
+
+    final additionalInfoElements = document.getElementsByClassName('hAyfc');
+    final versionElement = additionalInfoElements.firstWhere(
       (elm) => elm.querySelector('.BgcNfc')!.text == 'Current Version',
     );
+    final storeVersion = versionElement.querySelector('.htlgb')!.text;
+
+    final sectionElements = document.getElementsByClassName('W4P4ne');
+    final releaseNotesElement = sectionElements.firstWhere(
+      (elm) => elm.querySelector('.wSaTQd')!.text == 'What\'s New',
+    );
+    final releaseNotes = releaseNotesElement
+        .querySelector('.PHBdkd')
+        ?.querySelector('.DWPxHb')
+        ?.text;
+
     return VersionStatus._(
       localVersion: packageInfo.version,
-      storeVersion: versionElement.querySelector('.htlgb')!.text,
+      storeVersion: storeVersion,
       appStoreLink: uri.toString(),
+      releaseNotes: releaseNotes,
     );
   }
 


### PR DESCRIPTION
Closes #38 

This exposes the release notes listed for a published app as a field `releaseNotes` on the `VersionStatus` object.