### PR TITLE
Added open store method and force app version field

### DIFF
--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -77,9 +77,9 @@ class NewVersion {
   /// See http://en.wikipedia.org/wiki/ ISO_3166-1_alpha-2 for a list of ISO Country Codes.
   final String? iOSAppStoreCountry;
 
-  /// Only use for testing purpose. If you ues [forceAppVersion] then `getVersionStatus()`
-  /// always return [storeVersion] equal to [forceAppVersion]. It is can be used
-  /// to test by manually setting app version.
+  /// An optional value that will force the plugin to always return [forceAppVersion]
+  /// as the value of [storeVersion]. This can be useful to test the plugin's behavior
+  /// before publishng a new version.
   final String? forceAppVersion;
 
   NewVersion({
@@ -201,7 +201,7 @@ class NewVersion {
 
     final updateButtonTextWidget = Text(updateButtonText);
     final updateAction = () {
-      _launchAppStore(versionStatus.appStoreLink);
+      launchAppStore(versionStatus.appStoreLink);
       if (allowDismissal) {
         Navigator.of(context, rootNavigator: true).pop();
       }
@@ -258,7 +258,7 @@ class NewVersion {
   }
 
   /// Launches the Apple App Store or Google Play Store page for the app.
-  Future<void> _launchAppStore(String appStoreLink) async {
+  Future<void> launchAppStore(String appStoreLink) async {
     debugPrint(appStoreLink);
     if (await canLaunch(appStoreLink)) {
       await launch(appStoreLink);
@@ -266,8 +266,4 @@ class NewVersion {
       throw 'Could not launch appStoreLink';
     }
   }
-
-  /// Launches the Apple App Store or Google Play Store page for the app.
-  Future<void> openStore(VersionStatus versionStatus) =>
-      _launchAppStore(versionStatus.appStoreLink);
 }

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -252,7 +252,7 @@ class NewVersion {
   }
 
   /// Launches the Apple App Store or Google Play Store page for the app.
-  void _launchAppStore(String appStoreLink) async {
+  Future<void> _launchAppStore(String appStoreLink) async {
     debugPrint(appStoreLink);
     if (await canLaunch(appStoreLink)) {
       await launch(appStoreLink);
@@ -260,4 +260,8 @@ class NewVersion {
       throw 'Could not launch appStoreLink';
     }
   }
+
+  /// Launches the Apple App Store or Google Play Store page for the app.
+  Future<void> openStore(VersionStatus versionStatus) =>
+      _launchAppStore(versionStatus.appStoreLink);
 }

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -77,10 +77,16 @@ class NewVersion {
   /// See http://en.wikipedia.org/wiki/ ISO_3166-1_alpha-2 for a list of ISO Country Codes.
   final String? iOSAppStoreCountry;
 
+  /// Only use for testing purpose. If you ues [forceAppVersion] then `getVersionStatus()`
+  /// always return [storeVersion] equal to [forceAppVersion]. It is can be used
+  /// to test by manually setting app version.
+  final String? forceAppVersion;
+
   NewVersion({
     this.androidId,
     this.iOSId,
     this.iOSAppStoreCountry,
+    this.forceAppVersion,
   });
 
   /// This checks the version status, then displays a platform-specific alert
@@ -129,7 +135,7 @@ class NewVersion {
     }
     return VersionStatus._(
       localVersion: packageInfo.version,
-      storeVersion: jsonObj['results'][0]['version'],
+      storeVersion: forceAppVersion ?? jsonObj['results'][0]['version'],
       appStoreLink: jsonObj['results'][0]['trackViewUrl'],
       releaseNotes: jsonObj['results'][0]['releaseNotes'],
     );
@@ -165,7 +171,7 @@ class NewVersion {
 
     return VersionStatus._(
       localVersion: packageInfo.version,
-      storeVersion: storeVersion,
+      storeVersion: forceAppVersion ?? storeVersion,
       appStoreLink: uri.toString(),
       releaseNotes: releaseNotes,
     );


### PR DESCRIPTION
Some user (including me) may want to open store link manually without needing to show dialog, similar to the advanced example where user manually open dialog.
```dart
OutlinedButton.icon(
  style: OutlinedButton.styleFrom(
    primary: AppColor.scaffoldBackground,
    side: const BorderSide(
      color: AppColor.scaffoldBackground,
    ),
  ),
  onPressed: () {
    //update app
    _newVersion.openStore(versionStatus);
  },
  icon: const Icon(Icons.cloud_download_outlined),
  label: const Text('Update now'), // TODO: translation
);
```

Also I have added `forceAppVersion` field so we can test by manually setting store app version.
```dart
final _newVersion = NewVersion(forceAppVersion: '2.2.3');

```