### PR TITLE
Prevent caching

### DIFF
--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -111,7 +111,7 @@ class NewVersion {
   /// JSON document.
   Future<VersionStatus?> _getiOSStoreVersion(PackageInfo packageInfo) async {
     final id = iOSId ?? packageInfo.packageName;
-    final parameters = {"bundleId": "$id"};
+    final parameters = {"bundleId": "$id", "timestamp":"${DateTime.now().millisecondsSinceEpoch}"};
     if (iOSAppStoreCountry != null) {
       parameters.addAll({"country": iOSAppStoreCountry!});
     }
@@ -139,8 +139,9 @@ class NewVersion {
   Future<VersionStatus?> _getAndroidStoreVersion(
       PackageInfo packageInfo) async {
     final id = androidId ?? packageInfo.packageName;
+    final parameters = {"id": "$id", "timestamp":"${DateTime.now().millisecondsSinceEpoch}"};
     final uri =
-        Uri.https("play.google.com", "/store/apps/details", {"id": "$id"});
+        Uri.https("play.google.com", "/store/apps/details", parameters);
     final response = await http.get(uri);
     if (response.statusCode != 200) {
       debugPrint('Can\'t find an app in the Play Store with the id: $id');


### PR DESCRIPTION
Adding timestamp to urls on android and iOS to prevent internal caching and to get the latest version.