### PR TITLE
Add unnamed constructor packages update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0 - 5/12/22
+* Add unnamed constructor to improve testing and mocking
+* Fix lint warnings
+* Bump packages to latest versions
+
 ## 0.3.0 - 1/13/21
 * #75: Add `forceAppVersion` field to make testing easier.
 * #77: Improve `canUpdate` logic so that greater local version won't prompt for an update.

--- a/lib/new_version.dart
+++ b/lib/new_version.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 /// Information about the app's current version, and the most recent version
 /// available in the Apple App Store or Google Play Store.
@@ -51,7 +51,7 @@ class VersionStatus {
     return false;
   }
 
-  VersionStatus._({
+  VersionStatus({
     required this.localVersion,
     required this.storeVersion,
     required this.appStoreLink,
@@ -109,6 +109,7 @@ class NewVersion {
     } else {
       debugPrint(
           'The target platform "${Platform.operatingSystem}" is not yet supported by this package.');
+      return null;
     }
   }
 
@@ -137,7 +138,7 @@ class NewVersion {
       debugPrint('Can\'t find an app in the App Store with the id: $id');
       return null;
     }
-    return VersionStatus._(
+    return VersionStatus(
       localVersion: _getCleanVersion(packageInfo.version),
       storeVersion:
           _getCleanVersion(forceAppVersion ?? jsonObj['results'][0]['version']),
@@ -174,7 +175,7 @@ class NewVersion {
         ?.querySelector('.DWPxHb')
         ?.text;
 
-    return VersionStatus._(
+    return VersionStatus(
       localVersion: _getCleanVersion(packageInfo.version),
       storeVersion: _getCleanVersion(forceAppVersion ?? storeVersion),
       appStoreLink: uri.toString(),
@@ -265,8 +266,8 @@ class NewVersion {
   /// Launches the Apple App Store or Google Play Store page for the app.
   Future<void> launchAppStore(String appStoreLink) async {
     debugPrint(appStoreLink);
-    if (await canLaunch(appStoreLink)) {
-      await launch(appStoreLink);
+    if (await canLaunchUrlString(appStoreLink)) {
+      await launchUrlString(appStoreLink);
     } else {
       throw 'Could not launch appStoreLink';
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: new_version
 description: Check if your user has the most recent version of your Flutter app.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/timtraversy/new_version
 
 environment:
@@ -9,11 +9,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^1.0.0
-  http: ^0.13.1
+  package_info_plus: ^1.4.2
+  http: ^0.13.4
   html: ^0.15.0
-  url_launcher: ^6.0.2
-  collection: ^1.15.0
+  url_launcher: ^6.1.0
+  collection: ^1.16.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   package_info_plus: ^1.4.2
   http: ^0.13.4
   html: ^0.15.0
-  url_launcher: ^6.1.0
+  url_launcher: ^6.1.2
   collection: ^1.16.0
 
 dev_dependencies:


### PR DESCRIPTION
Hey,

i created a small merge request to make this package more testable/mockable.

At the moment we can not create mocks for `getVersionStatus` because we can not create a own instance of `VersionStatus` as long as there is no public constructors. So i changed it to a unnamed constructor.

I applied small lint fixes as well and updated some packages and remove deprecated function calls